### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Test update to link to Azure Board Work Item
 Adding for further test
 Testing to close
+Trying again

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/niclas0371/c2cbbeb9-071a-444e-b259-f23b6d7161ad/0a6da8cf-0ac2-40c3-a9bc-d9a129c4fe3e/_apis/work/boardbadge/f09a6935-e9c1-4fb0-889b-8c697d91de23)](https://dev.azure.com/niclas0371/c2cbbeb9-071a-444e-b259-f23b6d7161ad/_boards/board/t/0a6da8cf-0ac2-40c3-a9bc-d9a129c4fe3e/Microsoft.RequirementCategory)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 [![Board Status](https://dev.azure.com/niclas0371/c2cbbeb9-071a-444e-b259-f23b6d7161ad/0a6da8cf-0ac2-40c3-a9bc-d9a129c4fe3e/_apis/work/boardbadge/f09a6935-e9c1-4fb0-889b-8c697d91de23)](https://dev.azure.com/niclas0371/c2cbbeb9-071a-444e-b259-f23b6d7161ad/_boards/board/t/0a6da8cf-0ac2-40c3-a9bc-d9a129c4fe3e/Microsoft.RequirementCategory)
 
 Test update to link to Azure Board Work Item
+Adding for further test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 [![Board Status](https://dev.azure.com/niclas0371/c2cbbeb9-071a-444e-b259-f23b6d7161ad/0a6da8cf-0ac2-40c3-a9bc-d9a129c4fe3e/_apis/work/boardbadge/f09a6935-e9c1-4fb0-889b-8c697d91de23)](https://dev.azure.com/niclas0371/c2cbbeb9-071a-444e-b259-f23b6d7161ad/_boards/board/t/0a6da8cf-0ac2-40c3-a9bc-d9a129c4fe3e/Microsoft.RequirementCategory)
+
+Test update to link to Azure Board Work Item

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 Test update to link to Azure Board Work Item
 Adding for further test
+Testing to close


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#643](https://dev.azure.com/niclas0371/c2cbbeb9-071a-444e-b259-f23b6d7161ad/_workitems/edit/643). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.